### PR TITLE
Fix "ERROR! Syntax Error while loading YAML."

### DIFF
--- a/tasks/ssh-users.yml
+++ b/tasks/ssh-users.yml
@@ -1,7 +1,7 @@
 ---
   - name: Add additional public keys
     blockinfile:
-      dest: {{ ssh_auth_keys_file }}
+      dest: "{{ ssh_auth_keys_file }}"
       block: |
         # {{ item.name }}
         {{ item.key }}


### PR DESCRIPTION
This is a tiny fix to the following error:

```
ERROR! Syntax Error while loading YAML.


The error appears to have been in '/Users/Aucun/Code/gamesecure/bin/roles/invokemedia.laravel-settler/tasks/ssh-users.yml': line 4, column 14, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    blockinfile:
      dest: {{ ssh_auth_keys_file }}
             ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

I am using Ansible v2.2.1.0 with an almost out-of-the-box usage of this role.