### PR TITLE
Automatically install letsencrypt cert if enabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,4 @@ settler_nginx_site_public_folder: /public
 
 settler_letsencrypt: no
 # settler_letsencrypt_domain: localhost
+settler_letsencrypt_email: webmaster@invokedigital.co

--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -1,0 +1,36 @@
+---
+
+- name: install letsencrypt from apt
+  apt: name=letsencrypt update_cache=yes
+  sudo: yes
+
+- name: prepare letsencrypt domain proof folder
+  file: path="{{ settler_nginx_site_folder_root }}{{ settler_nginx_site_public_folder }}" state=directory
+  sudo: no
+
+- name: prepare server for proving domain ownership
+  template: src=nginx-default-domain-proof.j2 dest={{ item }}
+  with_items:
+    - /etc/nginx/sites-enabled/default
+    - /etc/nginx/sites-available/default
+
+- name: boot up server in non-https to prove domain ownership
+  service: name=nginx state=restarted
+
+- name: use letsencrypt webroot plugin
+  command: |
+    letsencrypt certonly
+    -a webroot
+    --webroot-path={{ settler_nginx_site_folder_root }}{{ settler_nginx_site_public_folder }}
+    -d {{ settler_letsencrypt_domain }}
+    --non-interactive
+    --agree-tos
+    --email {{ settler_letsencrypt_email }}
+  sudo: yes
+  notify: restart nginx
+
+- name: reset nginx sites template
+  template: src=nginx-default.j2 dest={{ item }}
+  with_items:
+    - /etc/nginx/sites-enabled/default
+    - /etc/nginx/sites-available/default

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -225,3 +225,14 @@
 #- command: dd if=/dev/zero of=/EMPTY bs=1M
 #- command: rm -f /EMPTY
 #- command: sync
+
+- name: check if we need to install letsencrypt
+  stat: path="/etc/letsencrypt/live/{{ settler_letsencrypt_domain }}/fullchain.pem"
+  register: pem
+  tags: letsencrypt
+
+- include: letsencrypt.yml
+  when:
+    - settler_letsencrypt == "yes"
+    - not pem.stat.exists
+  tags: letsencrypt

--- a/templates/nginx-default-domain-proof.j2
+++ b/templates/nginx-default-domain-proof.j2
@@ -1,0 +1,82 @@
+server {
+    listen {{ settler_nginx_default_server | default("80") }};
+    server_name {{ settler_nginx_server_name | default("localhost") }};
+
+    {% if settler_nginx_ipv6 %}
+    listen [::]:{{ settler_nginx_default_server | default("80") }} ipv6only=on;
+    {% endif %}
+
+    root {{ settler_nginx_site_folder_root }}{{ settler_nginx_site_public_folder }};
+
+    index index.php index.html index.htm;
+
+    charset utf-8;
+
+    client_max_body_size 12M;
+
+    gzip on;
+    gzip_vary on;
+    gzip_disable "msie6";
+    gzip_comp_level 6;
+    gzip_min_length 1100;
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        image/svg+xml
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/xml+rss;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        try_files $uri /index.php =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    # Expire rules for static content
+    # From HTML5 BP Configs: https://goo.gl/R1Xi5X
+
+    # cache.appcache, your document html and data
+    location ~* \.(?:manifest|appcache|html?|xml|json)$ {
+        expires -1;
+        # access_log logs/static.log; # I don't usually include a static log
+    }
+
+    # Feed
+    location ~* \.(?:rss|atom)$ {
+        expires 1h;
+        add_header Cache-Control "public";
+    }
+
+    # Media: images, icons, video, audio, HTC
+    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+        expires 1M;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    # CSS and Javascript
+    location ~* \.(?:css|js)$ {
+        expires 1y;
+        access_log off;
+        add_header Cache-Control "public";
+    }
+
+    location ~ /.well-known {
+      allow all;
+    }
+}


### PR DESCRIPTION
`settler_letsencrypt: yes` was behaving a little bit wonky. If provisioning a brand new EC2 instance with this flag on, nginx would fail because the cert didn't exist yet. However if the instance was provisioned first with the flag off, then the cert was added, then the instance was provisioned with the flag on, everything was working fine.

This commit simply automates that process in `letsencrypt.yml`. If the cert doesn't exist, then that file will start up a non-http version of the server, set up the certificate in non-interactive mode, then restore the server to its SSL settings.