### PR TITLE
Move ssh_list to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 add_ssh_users: false
 ssh_auth_keys_file: "/home/{{ ansible_ssh_user }}/.ssh/authorized_keys"
 
+# the list of users and their public keys
+ssh_list:
+  # - { name: username, key: ssh-rsa RANDOM_STRING webmaster@invokedigital.co, state: 'present' }
+
 # update the cache?
 settler_update_cache: yes
 # cache timeout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -220,6 +220,7 @@
 # includes
 - include: sysctl-tweaks.yml
 - include: ssh-users.yml
+  tags: ssh-users
 
 # Minimize The Disk Image
 #- command: dd if=/dev/zero of=/EMPTY bs=1M

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,2 @@
 ---
 # vars file for settler
-
-# the list of users and their public keys
-ssh_list:
-  # - { name: username, key: ssh-rsa RANDOM_STRING webmaster@invokedigital.co, state: 'present' }


### PR DESCRIPTION
According to [Ansible variable precedence](http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable), role vars take precedence over play vars_files. Therefore, `ssh_list` makes more sense as a default var so that playbook variable files take precedence.