### PR TITLE
Fix letsencrypt domain undefined error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,6 +244,7 @@
   stat: path="/etc/letsencrypt/live/{{ settler_letsencrypt_domain }}/fullchain.pem"
   register: pem
   tags: letsencrypt
+  when: settler_letsencrypt_domain is defined
 
 # includes
 - include: letsencrypt.yml


### PR DESCRIPTION
If we are not using letsencrypt, then we can safely leave out any warnings pertaining to settler_letsencrypt_domain being undefined.