### PR TITLE
Split php-fpm.ini into .local.ini and .ini

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,6 @@ settler_nginx_site_public_folder: /public
 settler_letsencrypt: no
 # settler_letsencrypt_domain: localhost
 settler_letsencrypt_email: webmaster@invokedigital.co
+
+# php.ini setup
+settler_php_fpm_ini_template: php-fpm.ini

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,7 +127,7 @@
 
 # Setup a site for nginx
 - name: set some php fpm settings
-  template: src=php-fpm.ini dest=/etc/php/7.0/fpm/php.ini
+  template: src={{ settler_php_fpm_ini_template }} dest=/etc/php/7.0/fpm/php.ini
   notify:
     - restart php-fpm
     - restart nginx

--- a/templates/php-fpm.local.ini
+++ b/templates/php-fpm.local.ini
@@ -1,0 +1,12 @@
+cgi.fix_pathinfo=0
+
+error_reporting = E_ALL
+display_errors = On
+
+memory_limit = 512M
+post_max_size = 32M
+upload_max_filesize = 32M
+date.timezone = UTC
+
+max_file_uploads = 10
+realpath_cache_size = 1M


### PR DESCRIPTION
This commit comes along and splits php-fpm.ini into a separate php-fpm.local.ini for local development when `settler_php_fpm_ini_template=php-fpm.local.ini`.